### PR TITLE
fix RAMの少ないマイコンでmemory allocation failedを防ぐ

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps = wasm3/Wasm3@^0.5.0
 build_flags = 
     ${env.build_flags}
     -DESP32
+    -DUSE_COREMARK
     -DCORE_DEBUG_LEVEL=5
     -Os
 
@@ -80,5 +81,4 @@ lib_deps = wasm3/Wasm3@^0.5.0
 build_flags = 
     ${env.build_flags}
     -DESP32
-    -DUSE_COREMARK
     -DCORE_DEBUG_LEVEL=5

--- a/src/lib/roader/wasm-roader.hpp
+++ b/src/lib/roader/wasm-roader.hpp
@@ -16,8 +16,8 @@
 // wasm3のexampleの値に従う
 // m3_NewRuntimeの第2引数
 // https://github.com/wasm3/wasm3-arduino/blob/main/src/m3_env.c#L170
-#define WASM_STACK_SLOTS (32 * 2024)
-
-#define NATIVE_STACK_SIZE (32 * 2024)
+// ここの値を大きくするとRAMの小さいマイコンでFatal: m3_LoadModule memory allocation failed になる
+#define WASM_STACK_SLOTS 2048
+#define NATIVE_STACK_SIZE (32 * 2028)
 
 void wasm_task(void *);

--- a/src/lib/roader/wasm-roader.hpp
+++ b/src/lib/roader/wasm-roader.hpp
@@ -18,6 +18,6 @@
 // https://github.com/wasm3/wasm3-arduino/blob/main/src/m3_env.c#L170
 // ここの値を大きくするとRAMの小さいマイコンでFatal: m3_LoadModule memory allocation failed になる
 #define WASM_STACK_SLOTS 2048
-#define NATIVE_STACK_SIZE (32 * 2028)
+#define NATIVE_STACK_SIZE (32 * 2048)
 
 void wasm_task(void *);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,11 @@ void setup()
   while (!Serial)
   {
   }
-  Serial.println(cos(0));
-
   Serial.println("Project Mahiwa started🎉");
 #ifdef ESP32
   Serial.println("ESP32 Mode");
   Serial.print("CPU Frequency:");
-  Serial.print(ESP.getCpuFreqMHz());
+  Serial.print(getCpuFrequencyMhz());
   Serial.println(" MHz");
   // xTaskCreatePinnedToCoreはFreeRTOSの関数
   // ESP32ではデフォルトでFreeRTOSが組み込まれているため下記のような形となる．


### PR DESCRIPTION
# 概要
ベンチマーク測り中に，ATOM Matrixで
```
memory allocation failed
```
になって気づいた．

# 備考・メモ
