### PR TITLE
fix picoに全体適応のコンパイラオプション指定していなかった

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,9 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+; coremark測定時に宣言するやつ
+; USE_COREMARK
+
 [env]
 framework = arduino
 monitor_speed = 115200
@@ -24,7 +27,6 @@ lib_deps = wasm3/Wasm3@^0.5.0
 build_flags = 
     ${env.build_flags}
     -DESP32
-    -DUSE_COREMARK
     -DCORE_DEBUG_LEVEL=5
     -Os
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,7 @@ lib_deps = wasm3/Wasm3@^0.5.0
 # ubuntu
 upload_port = /media/usuyuki/RPI-RP2
 build_flags = 
+    ${env.build_flags}
     ; picoのデフォルトのヒープは2048byteだが，wasmは1pで64kbの線形メモリなので足りない
     ; 基本的に2ページで収まるが3ページ分用意しておく
     ; ↓これ効かない

--- a/src/lib/roader/wasm-roader.hpp
+++ b/src/lib/roader/wasm-roader.hpp
@@ -16,8 +16,9 @@
 // wasm3のexampleの値に従う
 // m3_NewRuntimeの第2引数
 // https://github.com/wasm3/wasm3-arduino/blob/main/src/m3_env.c#L170
-// ここの値を大きくするとRAMの小さいマイコンでFatal: m3_LoadModule memory allocation failed になる
+// ここの値を大きくするとRAMの小さいマイコンでFatal: m3_LoadModule memory allocation failed になる see:https://github.com/project-mahiwa/mahiwa-backend/issues/99#issuecomment-1859609898
 #define WASM_STACK_SLOTS 2048
+// ここが小さいと実行途中にpanicになる see:https://github.com/project-mahiwa/mahiwa-frontend-go/issues/31
 #define NATIVE_STACK_SIZE (32 * 2048)
 
 void wasm_task(void *);


### PR DESCRIPTION
# 概要

close https://github.com/project-mahiwa/mahiwa-backend/issues/102

# 備考・メモ
